### PR TITLE
Magic Kayboard(JIS配列)のProductIDを追加。EjectとFnは認識されていない。

### DIFF
--- a/Misuzilla.Applications.AppleWirelessKeyboardHelper/Helper.cs
+++ b/Misuzilla.Applications.AppleWirelessKeyboardHelper/Helper.cs
@@ -34,6 +34,7 @@ namespace Misuzilla.Applications.AppleWirelessKeyboardHelper
         private const UInt32 PIDAppleWirelessKeyboardJIS_MC184JA = 0x23b;
         private const UInt32 PIDAppleWirelessKeyboardJIS_MC184JB = 0x257;
         private const UInt32 PIDAppleKeyboardWithoutTenKeyUS = 0x21d;
+        private const UInt32 PIDAppleMagicKeyboardJIS = 0x267;
 
         /// <summary>
         /// 
@@ -77,7 +78,8 @@ namespace Misuzilla.Applications.AppleWirelessKeyboardHelper
                               attrib.ProductID == PIDAppleWirelessKeyboardJIS_MC184JA ||
                               attrib.ProductID == PIDAppleWirelessKeyboardJIS_MC184JB ||
                               attrib.ProductID == PIDAppleWirelessKeyboardUS_MC184LL ||
-                              attrib.ProductID == PIDAppleWirelessKeyboardUS_MC184LLB
+                              attrib.ProductID == PIDAppleWirelessKeyboardUS_MC184LLB ||
+                              attrib.ProductID == PIDAppleMagicKeyboardJIS
                         ))
                         {
                             _stream = new FileStream(mHandle, FileAccess.ReadWrite, 22, true);


### PR DESCRIPTION
Apple Magic Keyboardにも対応できるよう、私が所有しているJIS配列のもののみProductIDを追加しました。
Eject、FnキーはHookされないので、現状無視しています。
